### PR TITLE
Roll back partial reservation writes on the fallback create path

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -656,14 +656,87 @@ async function createEventsIndividually(validatedEvents, validationUsers) {
             index,
             index + EVENT_CREATE_FALLBACK_CONCURRENCY
         );
-        const chunkResults = await Promise.all(chunk.map(eventForBackend => {
+        const chunkResults = await Promise.allSettled(chunk.map(eventForBackend => {
             return createValidatedEvent(eventForBackend, validationUsers);
         }));
 
-        createdEvents.push(...chunkResults);
+        for (const chunkResult of chunkResults) {
+            if (chunkResult.status === "fulfilled") {
+                createdEvents.push(chunkResult.value);
+            }
+        }
+
+        const failedResult = chunkResults.find(chunkResult => {
+            return chunkResult.status === "rejected";
+        });
+
+        if (failedResult) {
+            const abandonedEvents = await rollBackCreatedEvents(createdEvents);
+
+            if (abandonedEvents.length > 0) {
+                throw buildAbandonedReservationsError(abandonedEvents);
+            }
+
+            throw failedResult.reason;
+        }
     }
 
     return createdEvents;
+}
+
+function toReservationId(value) {
+    if (value === null || value === undefined || value === "") {
+        return null;
+    }
+
+    const numberValue = Number(value);
+
+    return Number.isInteger(numberValue) && numberValue > 0 ? numberValue : null;
+}
+
+async function rollBackCreatedEvents(createdEvents) {
+    const abandonedEvents = [];
+
+    for (const createdEvent of createdEvents) {
+        const eventId = toReservationId(createdEvent?.id);
+
+        if (eventId === null) {
+            abandonedEvents.push(createdEvent);
+            continue;
+        }
+
+        try {
+            await deleteEvent({ id: eventId });
+        } catch (error) {
+            console.error(
+                "Could not roll back reservation after a failed batch:",
+                eventId,
+                error
+            );
+            abandonedEvents.push(createdEvent);
+        }
+    }
+
+    return abandonedEvents;
+}
+
+function buildAbandonedReservationsError(abandonedEvents) {
+    const identifiers = abandonedEvents
+        .map(abandonedEvent => toReservationId(abandonedEvent?.id))
+        .filter(eventId => eventId !== null);
+    const identifierSummary = identifiers.length > 0
+        ? ` (reservation ${identifiers.length === 1 ? "ID" : "IDs"}: ${identifiers.join(", ")})`
+        : "";
+    const error = new Error(
+        `Only part of this booking could be saved, and ${abandonedEvents.length} ` +
+        `${abandonedEvents.length === 1 ? "reservation" : "reservations"} could not be ` +
+        `removed automatically${identifierSummary}. Please delete ` +
+        `${abandonedEvents.length === 1 ? "it" : "them"} before trying again.`
+    );
+
+    error.data = { error: error.message };
+
+    return error;
 }
 
 async function createValidatedEvent(eventForBackend, validationUsers) {


### PR DESCRIPTION
Fixes a data-integrity bug in the fallback reservation-create path introduced with the recurring-reservation work.

## The bug

`createEventsIndividually()` ran chunks of 8 through `Promise.all`:

```js
const chunkResults = await Promise.all(chunk.map(eventForBackend =>
    createValidatedEvent(eventForBackend, validationUsers)
));
createdEvents.push(...chunkResults);
```

If any single create rejected, `Promise.all` rejected the whole chunk — but every event already written in prior chunks stayed in the database. The caller surfaced "Could not save the reservations to the backend", so the user saw total failure, retried, and ended up with **duplicate reservations plus orphaned partials they had no way to see or remove**.

This is not an edge case. The fallback fires on 404/405/50x — that is, whenever `/events/recurring` and `/events/batch` are unavailable, which is precisely what happens when the deployed backend is older than the frontend.

## The fix

- `Promise.allSettled` instead of `Promise.all`, so successes are captured even when a sibling in the same chunk fails.
- On failure, delete everything created so far, then rethrow. The fallback now has the same all-or-nothing semantics the batch endpoint already provides, so callers don't have to reason about two different contracts.
- If the rollback *itself* fails — often the same outage that broke the create — the error names the reservations left behind instead of claiming nothing was saved. It sets `data.error`, the shape `getRequestFailureMessage()` already reads, so the message reaches the user unchanged with no caller changes.
- Ids are guarded with a new `toReservationId()` rather than the existing `normalizeInteger()`. `Number(null)` and `Number("")` are both `0`, so the obvious version of this guard would have issued `DELETE /events/0`.

Frontend only. No backend changes.

## Verification

There is no test infrastructure in this repo, so I drove the logic from a scratch harness that extracts the functions verbatim from `api.js` and stubs the network calls — 23 assertions, all passing:

| scenario | asserted |
|---|---|
| all creates succeed | all 20 returned, zero deletes issued |
| failure in chunk 2, rollback OK | **original** error rethrown; all 15 created events deleted; no `DELETE /events/0` |
| rollback also fails | error names the 7 orphans and their IDs; `data.error` set for passthrough |
| created event has no id | counted as abandoned, never `DELETE`d |
| `toReservationId` | rejects `null`, `undefined`, `""`, `0`, `-1`, `1.5`, `"abc"`; accepts `7` and `"7"` |

Also confirmed all 18 frontend modules still parse (`node --check`).

The harness is not committed — wiring up a real test runner is a bigger call than this fix, and worth doing deliberately. Happy to open that separately; this repo currently has no automated tests at all.

## Not addressed here

`ReservationController` has **no overlap or double-booking check on any endpoint**, and `events` has no room column — so any two events overlapping in time are a conflict, and nothing prevents them. That predates this work and needs a schema decision (a `tstzrange` exclusion constraint would enforce it at the DB, but it will not apply if overlapping rows already exist). Flagging, not fixing.
