### PR TITLE
Prevent reservations from being scheduled in the past

### DIFF
--- a/backend/src/main/java/com/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/reservation/controller/ReservationController.java
@@ -61,7 +61,7 @@ public class ReservationController {
     @PostMapping
     public ResponseEntity<String> create(@RequestBody String body, HttpServletRequest request) {
         try {
-            ObjectNode eventBody = normalizeEventBody(body);
+            ObjectNode eventBody = normalizeNewEventBody(body);
 
             if (!canSaveWithRequestedHost(request, eventBody)) {
                 return jsonError(403, "You do not have permission to save this reservation for that host.");
@@ -91,7 +91,7 @@ public class ReservationController {
                 ObjectNode eventBody;
 
                 try {
-                    eventBody = normalizeEventInput(inputEvents.get(index));
+                    eventBody = normalizeNewEventInput(inputEvents.get(index));
                 } catch (IllegalArgumentException error) {
                     return jsonError(400, "Reservation " + (index + 1) + ": " + error.getMessage());
                 }
@@ -166,7 +166,7 @@ public class ReservationController {
                     ObjectNode eventBody;
 
                     try {
-                        eventBody = normalizeEventInput(occurrenceInput);
+                        eventBody = normalizeNewEventInput(occurrenceInput);
                     } catch (IllegalArgumentException error) {
                         return jsonError(
                             400,
@@ -260,6 +260,24 @@ public class ReservationController {
         } catch (Exception error) {
             throw new IllegalArgumentException("Event body could not be parsed.");
         }
+    }
+
+    // New reservations may not start in the past. Updates deliberately skip this check so
+    // an already-past reservation stays correctable (fixing a title, host, or attendees).
+    private ObjectNode normalizeNewEventBody(String body) {
+        ObjectNode event = normalizeEventBody(body);
+
+        validateStartsInFuture(event);
+
+        return event;
+    }
+
+    private ObjectNode normalizeNewEventInput(JsonNode input) {
+        ObjectNode event = normalizeEventInput(input);
+
+        validateStartsInFuture(event);
+
+        return event;
     }
 
     private ObjectNode normalizeEventInput(JsonNode input) {
@@ -489,6 +507,17 @@ public class ReservationController {
 
         if (endTime.toLocalTime().isAfter(RESERVATION_DAY_END)) {
             throw new IllegalArgumentException("Reservations must end by 5:00 PM.");
+        }
+    }
+
+    private void validateStartsInFuture(ObjectNode event) {
+        ZonedDateTime startTime = parseReservationDateTime(
+            event.path("start_time").asText(),
+            "start_time"
+        );
+
+        if (!startTime.isAfter(ZonedDateTime.now(RESERVATION_TIME_ZONE))) {
+            throw new IllegalArgumentException("Reservations cannot be scheduled in the past.");
         }
     }
 

--- a/frontend/js/ui/reservationTimePicker.js
+++ b/frontend/js/ui/reservationTimePicker.js
@@ -177,6 +177,16 @@ export function createReservationTimePicker({
             `${formatDayLabel(slotStart)}, ${formatSlotRangeLabel(slotStart, slotEnd)}`
         );
 
+        // Past slots stay in the grid so an existing reservation still shows its
+        // selection, but they cannot start a drag or be dragged over.
+        if (isPastSlot(slotStart)) {
+            cell.classList.add("past");
+            cell.dataset.pickerPast = "true";
+            cell.disabled = true;
+
+            return cell;
+        }
+
         cell.addEventListener("pointerdown", event => {
             if (event.pointerType === "mouse" && event.button !== 0) {
                 return;
@@ -210,7 +220,11 @@ export function createReservationTimePicker({
             .elementFromPoint(event.clientX, event.clientY)
             ?.closest("[data-picker-cell='true']");
 
-        if (hoveredCell && container.contains(hoveredCell)) {
+        if (
+            hoveredCell &&
+            container.contains(hoveredCell) &&
+            hoveredCell.dataset.pickerPast !== "true"
+        ) {
             applyDragRange(hoveredCell);
         }
     }
@@ -532,6 +546,12 @@ function subtractRange(selectedRanges, removalRange) {
 function rangesOverlap(firstRange, secondRange) {
     return firstRange.start < secondRange.end &&
         firstRange.end > secondRange.start;
+}
+
+// Matches the save-time rule: a reservation must start after the current moment,
+// so a slot counts as past as soon as its start time has been reached.
+function isPastSlot(slotStart) {
+    return slotStart.getTime() <= Date.now();
 }
 
 function normalizeRanges(ranges = []) {

--- a/frontend/js/utils/reservationValidation.js
+++ b/frontend/js/utils/reservationValidation.js
@@ -68,6 +68,12 @@ function getReservationValidationMessage({
         return "End time must be after start time.";
     }
 
+    // Only new reservations are held to this. Editing an existing reservation stays
+    // allowed once it is in the past, so past records can still be corrected.
+    if (!requireId && !isInFuture(startDate)) {
+        return "Reservations cannot be scheduled in the past.";
+    }
+
     const timeWindowMessage = getReservationTimeWindowMessage(startDate, endDate);
 
     if (timeWindowMessage) {
@@ -184,6 +190,10 @@ function getReservationTimeWindowMessage(startDate, endDate) {
     }
 
     return "";
+}
+
+function isInFuture(date) {
+    return date.getTime() > Date.now();
 }
 
 function isBeforeDailyEnd(date) {

--- a/frontend/styles/modal.css
+++ b/frontend/styles/modal.css
@@ -310,6 +310,21 @@
         inset -1px 0 0 rgba(255, 255, 255, 0.26);
 }
 
+/* Slots that have already started cannot be booked. Declared after .selected so a
+   past slot reads as unavailable, with .past.selected keeping an existing
+   reservation visible when an earlier booking is opened for editing. */
+.reservation-time-picker-slot.past,
+.reservation-time-picker-slot.past:hover {
+    background: #f1f2f4;
+    color: #9aa1a9;
+    cursor: not-allowed;
+}
+
+.reservation-time-picker-slot.past.selected,
+.reservation-time-picker-slot.past.selected:hover {
+    background: rgba(2, 56, 103, 0.38);
+}
+
 .reservation-time-picker-boundary-label,
 .reservation-time-picker-boundary-cell {
     min-height: 18px;


### PR DESCRIPTION
Reservations could previously be created for times that had already passed — nothing in the backend or the frontend compared the start time against the current moment.

## Rules

New reservations must start **strictly after** the current moment (`America/Los_Angeles`, the zone the controller already uses). Updates are deliberately exempt, so an already-past reservation stays correctable — fixing a title, host, or attendees on a historical record still works.

## Backend

`ReservationController.validateStartsInFuture()` rejects a past `start_time` with a 400, wired into the three create paths via `normalizeNewEventBody` / `normalizeNewEventInput`:

- `POST /api/events`
- `POST /api/events/batch`
- `POST /api/events/recurring` — checked per occurrence, so a series whose first week has already passed fails with the existing `range N, week M: …` message

`PATCH /api/events/{id}` still calls plain `normalizeEventBody` and is unaffected.

## Frontend

- `reservationValidation.js` applies the same rule so the message appears before submitting, gated on `requireId` (which already means "existing reservation" everywhere it is used).
- The week picker greys out and disables every slot whose start time has passed. Past slots cannot begin a drag and are skipped while dragging, but stay in the grid so an earlier reservation still shows its selection when opened for editing.

Note: in `validateEditedReservations`, only `index === 0` is the existing reservation — extra occurrences appended while extending a recurring series count as new and do get the check.

## Verification

- `mvn compile` passes; both JS modules parse.
- Picker behaviour confirmed in a browser against a standalone harness: past cells disabled (90 of 126 for the current week), clicking a past cell selects nothing, a drag from a future slot backwards into past columns does not extend into them, and `setRange` into the past still renders the selection for the edit case.
- No automated tests were added — the repo has no test sources at all.

## Known gaps

- The grid does not re-grey as time passes while the modal is open; a slot that becomes past mid-session stays clickable until the next render. Both validation layers still reject it on save.
- Navigating to past weeks is still allowed (they render fully greyed), so earlier reservations remain viewable.